### PR TITLE
Proxy IInvocation interface through IMethodInvocation

### DIFF
--- a/src/StructureMap.DynamicInterception/IMethodInvocation.cs
+++ b/src/StructureMap.DynamicInterception/IMethodInvocation.cs
@@ -10,7 +10,11 @@ namespace StructureMap.DynamicInterception
 
         IArgument GetArgument(string name);
 
+        object TargetInstance { get; }
+
         MethodInfo MethodInfo { get; }
+
+        MethodInfo InstanceMethodInfo { get; }
 
         Type ActualReturnType { get; }
 


### PR DESCRIPTION
The properties of IInvocation should be proxied through IMethodInvocation. This will allow the implementation of interceptors to have full access to all metadata for the current method invocation.
